### PR TITLE
improve search with HGVS, Ensembl ids and HPO ids

### DIFF
--- a/views/autocomplete.py
+++ b/views/autocomplete.py
@@ -12,6 +12,16 @@ from views.exceptions import PhenopolisException
 from views.auth import requires_auth
 from views.postgres import postgres_cursor
 
+CHROMOSOME_POS_REGEX = re.compile(r"^(\w+)[-:](\d+)$")
+CHROMOSOME_POS_REF_REGEX = re.compile(r"^(\w+)[-:](\d+)[-:]([ACGT\*]+)$", re.IGNORECASE)
+CHROMOSOME_POS_REF_ALT_REGEX = re.compile(r"^(\w+)[-:](\d+)[-:]([ACGT\*]+)[-:>]([ACGT\*]+)$", re.IGNORECASE)
+ENSEMBL_TRANSCRIPT_REGEX = re.compile("^ENST(\d{0,10})", re.IGNORECASE)
+ENSEMBL_PROTEIN_REGEX = re.compile("^ENSP(\d{0,10})", re.IGNORECASE)
+ENSEMBL_GENE_REGEX = re.compile("^ENSG(\d{0,10})", re.IGNORECASE)
+HPO_REGEX = re.compile("^HP:(\d{0,7})", re.IGNORECASE)
+PATIENT_REGEX = re.compile("^PH(\d{0,8})", re.IGNORECASE)
+HGVSP = "hgvsp"
+HGVSC = "hgvsc"
 SEARCH_RESULTS_LIMIT = 20
 
 
@@ -31,13 +41,18 @@ def autocomplete(query, query_type=""):
     elif query_type == "patient":
         results = _search_patients(cursor, query)
     elif query_type == "variant":
-        results = _search_variants(cursor, query)
+        results_by_coordinates = _search_variants_by_coordinates(cursor, query)
+        results_by_hgvs = _search_variants_by_hgvs(cursor, query)
+        results = results_by_coordinates + results_by_hgvs
     elif query_type == "":
         results = (
             ["gene:" + x for x in _search_genes(cursor, query)]
             + ["phenotype:" + x for x in _search_phenotypes(cursor, query)]
             + ["patient:" + x for x in _search_patients(cursor, query)]
-            + ["variant:" + x for x in _search_variants(cursor, query)]
+            + [
+                "variant:" + x
+                for x in _search_variants_by_coordinates(cursor, query) + _search_variants_by_hgvs(cursor, query)
+            ]
         )
     else:
         message = "Autocomplete request with unsupported query type '{}'".format(query_type)
@@ -54,26 +69,36 @@ def _search_patients(cursor, query):
     r"""'
     Patient (internal_id) format: PH (PH\d{8}) e.g. 'PH00005862' and are restricted to a particular user
     'demo', for example, can only access ['PH00008256', 'PH00008258', 'PH00008267', 'PH00008268']
-    so, a search for '82', for user 'demo', should return only the 4 cases above
+    so, a search for 'PH000082', for user 'demo', should return only the 4 cases above
     """
-    cursor.execute(
-        r""" select i.external_id, i.internal_id from individuals i, users_individuals ui where
-        ui.internal_id=i.internal_id and ui.user=%(user)s and i.internal_id LIKE %(query)s limit %(limit)s""",
-        {"user": session["user"], "query": "%{}%".format(query.upper()), "limit": SEARCH_RESULTS_LIMIT},
-    )
-    patient_hits = cursor2dict(cursor)
+    if PATIENT_REGEX.match(query):
+        cursor.execute(
+            r""" select i.external_id, i.internal_id from individuals i, users_individuals ui where
+            ui.internal_id=i.internal_id and ui.user=%(user)s and i.internal_id ILIKE %(query)s limit %(limit)s""",
+            {"user": session["user"], "query": "{}%".format(query), "limit": SEARCH_RESULTS_LIMIT},
+        )
+        patient_hits = cursor2dict(cursor)
+    else:
+        patient_hits = []
     return [x["internal_id"] for x in patient_hits]
 
 
 def _search_phenotypes(cursor, query):
     """
-    A user may search for things like 'Abnormality of body height'
+    A user may search for things like 'Abnormality of body height' or for an HPO id as HP:1234567 (ie: HP:\d{7})
     """
-    cursor.execute(
-        r"""
-                   select * from hpo where UPPER(hpo_name) like %(query)s limit %(limit)s""",
-        {"query": "%{}%".format(query.upper()), "limit": SEARCH_RESULTS_LIMIT},
-    )
+    if HPO_REGEX.match(query):
+        cursor.execute(
+            r"""
+                       select * from hpo where hpo_id ilike %(query)s limit %(limit)s""",
+            {"query": "{}%".format(query), "limit": SEARCH_RESULTS_LIMIT},
+        )
+    else:
+        cursor.execute(
+            r"""
+                       select * from hpo where hpo_name ilike %(query)s limit %(limit)s""",
+            {"query": "%{}%".format(query), "limit": SEARCH_RESULTS_LIMIT},
+        )
     hpo_hits = cursor2dict(cursor)
     return [x["hpo_name"] for x in hpo_hits]
 
@@ -82,21 +107,30 @@ def _search_genes(cursor, query):
     """
     Either search for a gene_id like 'ensg000...', or by gene name like 'ttll...', or by gene synonym like 'asd...'
     """
-    cursor.execute(
-        r"""select * from genes where gene_name_upper like %(suffix_query)s or other_names like %(query)s
-        or gene_id like %(query)s limit %(limit)s""",
-        {
-            "suffix_query": "%{}%".format(query.upper()),
-            "query": "%{}%".format(query.upper()),
-            "limit": SEARCH_RESULTS_LIMIT,
-        },
-    )
+    if ENSEMBL_GENE_REGEX.match(query):
+        cursor.execute(
+            r"""select * from genes where "gene_id"::text ilike %(query)s limit %(limit)s""",
+            {"query": "{}%".format(query), "limit": SEARCH_RESULTS_LIMIT,},
+        )
+    elif ENSEMBL_TRANSCRIPT_REGEX.match(query):
+        # TODO: add search by all Ensembl transcipts (ie: not only canonical) if we add those to the genes table
+        cursor.execute(
+            r"""select * from genes where "canonical_transcript"::text ilike %(query)s limit %(limit)s""",
+            {"query": "{}%".format(query), "limit": SEARCH_RESULTS_LIMIT,},
+        )
+    # TODO: add search by Ensembl protein if we add a column to the genes table
+    else:
+        cursor.execute(
+            r"""select * from genes where gene_name_upper ilike %(suffix_query)s or other_names ilike %(query)s
+            limit %(limit)s""",
+            {"suffix_query": "%{}%".format(query), "query": "%{}%".format(query), "limit": SEARCH_RESULTS_LIMIT,},
+        )
     gene_hits = cursor2dict(cursor)
     # while the search is performed on the upper cased gene name, it returns the original gene name
     return [x["gene_name"] for x in gene_hits]
 
 
-def _search_variants(cursor, query):
+def _search_variants_by_coordinates(cursor, query):
     """
     Assuming a user is searching for 22-38212762-A-G or 22-16269829-T-*
     22-382
@@ -128,9 +162,44 @@ def _search_variants(cursor, query):
         # no variant pattern, we perform no search
         return []
     variant_hits = cursor2dict(cursor)
-    # while the search is performed on the upper cased gene name, it returns the original gene name
-    #     return [f"{x['CHROM']}-{x['POS']}-{x['REF']}-{x['ALT']}" for x in variant_hits]
     return ["{CHROM}-{POS}-{REF}-{ALT}".format(**x) for x in variant_hits]
+
+
+def _search_variants_by_hgvs(cursor, query):
+    """
+    Assuming a user is searching for ENSP00000451572.1:p.His383Tyr, ENST00000355467.4:c.30C>T or
+    ENST00000505973.1:n.97C>T
+    The queries need to do something like HGVSC like %query%, because the HGVS codes are a comma separated list in the
+    corresponding text column. The query must start with either ENST or ENSP to be performed
+    """
+    hgvs, hgvs_type = _parse_hgvs_from_query(query)
+    if hgvs_type == HGVSC:
+        cursor.execute(
+            r"""select "CHROM", "POS", "REF", "ALT" from variants where
+            "hgvsc"::text ilike %(hgvs)s limit %(limit)s""",
+            {"limit": SEARCH_RESULTS_LIMIT, "hgvs": "%" + hgvs + "%"},
+        )
+    elif hgvs_type == HGVSP:
+        cursor.execute(
+            r"""select "CHROM", "POS", "REF", "ALT" from variants where
+            "hgvsp"::text ilike %(hgvs)s limit %(limit)s""",
+            {"limit": SEARCH_RESULTS_LIMIT, "hgvs": "%" + hgvs + "%"},
+        )
+    else:
+        # no variant pattern, we perform no search
+        return []
+    variant_hits = cursor2dict(cursor)
+    return ["{CHROM}-{POS}-{REF}-{ALT}".format(**x) for x in variant_hits]
+
+
+def _parse_hgvs_from_query(query):
+    hgvs_type = None
+    hgvs = query
+    if ENSEMBL_PROTEIN_REGEX.match(query):
+        hgvs_type = HGVSP
+    if ENSEMBL_TRANSCRIPT_REGEX.match(query):
+        hgvs_type = HGVSC
+    return hgvs, hgvs_type
 
 
 def _parse_variant_from_query(query):
@@ -142,13 +211,13 @@ def _parse_variant_from_query(query):
     and alternate.
     """
     # TODO: remove the * from the accepted queries if we normalize indels to VCF-like format
-    match = re.compile(r"^(\w+)[-:](\d+)[-:]([ACGT\*]+)[-:>]([ACGT\*]+)$").match(query)
+    match = CHROMOSOME_POS_REF_ALT_REGEX.match(query)
     if match:
         return match.group(1), match.group(2), match.group(3), match.group(4)
-    match = re.compile(r"^(\w+)[-:](\d+)[-:]([ACGT\*]+)$").match(query)
+    match = CHROMOSOME_POS_REF_REGEX.match(query)
     if match:
         return match.group(1), match.group(2), match.group(3), None
-    match = re.compile(r"^(\w+)[-:](\d+)$").match(query)
+    match = CHROMOSOME_POS_REGEX.match(query)
     if match:
         return match.group(1), match.group(2), None, None
     return None, None, None, None


### PR DESCRIPTION
Issue #100 + some other stuff

Indices may need tweaking for performance I hope this kicks off this discussion as you are surely more knowledgeable than I am on postgres indices.

Changes in search:
* HGVS support. HGVS codes come in two flavours HGVS p (from protein) and HGVS c (from cDNA). Both start with an ensembl identifier (`ENSP0123456789` for proteins and `ENST0123456789` for transcripts). If you type in something starting with `ENSP` or `ENST` followed by at most 10 numbers you will start getting variant as a result for the search. Of course the search can be more precise like `ENST00000398558.4:c.1205C>T` or `ENSP00000381566.3:p.Ala402Val`; or somewhere in between `ENSP00000381566.3:p.Ala402`. This is done with `where "hgvsc"::text ilike %ENST00000398558.4:c.1205C>T%`. Why the `%` ate the beginning? Because the same variant can have multiple HGVS codes and this come in the same text column separated by commas. Currently the involved columns have no indices, I would need some advice here about the best index (@dvarrazzo?)
* Search by Ensembl ids. When you start typing an Ensemble id eg:`ENST0000039` you will also get results for genes. This is true only for Ensembl transcript ids and for Ensembl gene ids. We don't have the Ensembl protein id in the gene table, although we could. Also the results for genes are only based on the canonical transcript as we don't have all transcripts in the genes table. Other search by gene remains the same.
* Search by HPO ids. When you start typing an HPO id of the form `HP:` followed by at most 7 numbers you will get phenotypes as a result. The search by HPO name remains the same as before. We are missing in the HPOs table the synonyms which are useful resource to provide better results, for instance `intellectual disability` has a bunch of synonyms like `Low intelligence` see https://hpo.jax.org/app/browse/term/HP:0001249
* Search by patients. I have changed the search to be more restrictive, it now only provides results if the query follows the pattern `PH` +  at most 8 numbers. I have done this as it seems clearer to me, but happy to change it back.

General things:
* I have replaced all playing in Python with `.upper()` by postgres queries with `ilike` + regex patterns ignoring case, so all queries are still case insensitive.
* I have put all regex definition in constants so the `re.compile()` only happens once and not once per query. It is probably not a big deal in terms of performance but still.