### PR TITLE
add endpoint to create users

### DIFF
--- a/views/auth.py
+++ b/views/auth.py
@@ -9,6 +9,9 @@ from db import User
 from views import application
 from views.postgres import get_db_session
 
+PASSWORD = "password"
+USER = "user"
+
 
 def check_auth(username, password):
     """
@@ -24,13 +27,13 @@ def check_auth(username, password):
 def requires_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        if session.get("user"):
+        if session.get(USER):
             return f(*args, **kwargs)
         if request.method == "POST":
-            username = request.form["user"]
-            password = request.form["password"]
+            username = request.form[USER] if USER in request.form else request.headers[USER]
+            password = request.form[PASSWORD] if PASSWORD in request.form else request.headers[PASSWORD]
             if check_auth(username, password):
-                session["user"] = username
+                session[USER] = username
                 # session.permanent = True
                 return f(*args, **kwargs)
         return jsonify(error="Unauthenticated"), 401

--- a/views/users.py
+++ b/views/users.py
@@ -3,9 +3,12 @@ Users view
 """
 from flask import session, request, jsonify
 from passlib.handlers.argon2 import argon2
+
+from db import User
 from views import application
 from views.auth import requires_auth, check_auth
-from views.postgres import postgres_cursor
+from views.exceptions import PhenopolisException
+from views.postgres import postgres_cursor, get_db_session
 
 
 @application.route("/change_password", methods=["POST"])
@@ -31,3 +34,65 @@ def change_password():
     c.execute(""" update users set argon_password='%s' where user='%s' """ % (argon_password, session["user"],))
     msg = "Password for username '" + username + "' changed. You are logged in as '" + username + "'."
     return jsonify(success=msg), 200
+
+
+@application.route("/user", methods=["POST"])
+@requires_auth
+def create_user():
+    if session["user"] != "Admin":
+        return jsonify(error="You do not have permission to create new users"), 403
+
+    if not request.is_json:
+        return jsonify(success=False, error="Only mimetype application/json is accepted"), 400
+
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return jsonify(success=False, error="Empty payload or wrong formatting"), 400
+    application.logger.debug(payload)
+
+    # parse the JSON data into an individual, non existing fields will trigger a TypeError
+    try:
+        new_user = User(**payload)
+    except TypeError as e:
+        application.logger.error(str(e))
+        return jsonify(success=False, error=str(e)), 400
+
+    # checks individuals validity
+    try:
+        _check_user_valid(new_user)
+    except PhenopolisException as e:
+        application.logger.error(str(e))
+        return jsonify(success=False, error=str(e)), 400
+
+    # encode password
+    new_user.argon_password = argon2.hash(new_user.argon_password)
+
+    sqlalchemy_session = get_db_session()
+    request_ok = True
+    message = "User was created"
+    user_id = new_user.user
+    try:
+        # insert user
+        sqlalchemy_session.add(new_user)
+        sqlalchemy_session.commit()
+    except Exception as e:
+        sqlalchemy_session.rollback()
+        application.logger.exception(e)
+        request_ok = False
+        message = str(e)
+    finally:
+        sqlalchemy_session.close()
+
+    if not request_ok:
+        return jsonify(success=False, message=message), 500
+    else:
+        return jsonify(success=True, message=message, id=user_id), 200
+
+
+def _check_user_valid(new_user: User):
+    if new_user is None:
+        raise PhenopolisException("Null user")
+    if new_user.user is None or new_user.user == "":
+        raise PhenopolisException("Missing user name")
+    if new_user.argon_password is None or new_user.argon_password == "":
+        raise PhenopolisException("Missing password")


### PR DESCRIPTION
#89 
Adds an endpoint to create a user with username and password.

Only the `Admin` user is allowed to create users.

Authentication is done via header attributes `user` and `password` (these are for the Admin user!).
The POST must contain a JSON payload as follows:
```
{
    "user":"test_creation",
    "argon_password": "blabla"
}
```

The password is not saved in plain format in the db but encoded with argon as it has been done before.

Error conditions:

* Only Admin user is allowed to create other users
* Any other payload mimetype than application/json is rejected
* Empty payload
* Any field in the JSON not existing in the user SQLAlchemy model
* Empty `user` field
* Empty `argon_password` field

Pending to add tests here.
