### PR TITLE
89 create new user individuals

### DIFF
--- a/views/helpers.py
+++ b/views/helpers.py
@@ -22,4 +22,3 @@ def _parse_payload(payload, model_class):
     else:
         raise PhenopolisException("Payload of unexpected type: {}".format(type(payload)))
     return objects
-

--- a/views/individual.py
+++ b/views/individual.py
@@ -131,12 +131,15 @@ def _check_individual_valid(new_individual: Individual):
 
 def _get_new_individual_id(sqlalchemy_session):
     # NOTE: this is not robust if the database contains ids other than PH + 8 digits
-    latest_internal_id = sqlalchemy_session\
-        .query(Individual.internal_id).filter(Individual.internal_id.like("PH%"))\
-        .order_by(Individual.internal_id.desc()).first()
+    latest_internal_id = (
+        sqlalchemy_session.query(Individual.internal_id)
+        .filter(Individual.internal_id.like("PH%"))
+        .order_by(Individual.internal_id.desc())
+        .first()
+    )
     matched_id = re.compile("^PH(\d{8})$").match(latest_internal_id[0])
     if matched_id:
-        return "PH{}".format(str(int(matched_id.group(1)) + 1).zfill(8))    # pads with 0s
+        return "PH{}".format(str(int(matched_id.group(1)) + 1).zfill(8))  # pads with 0s
     else:
         raise PhenopolisException("Failed to fetch the latest internal id for an individual")
 
@@ -372,5 +375,3 @@ def _get_hpos(features):
         hpos.append(dict(zip(["hpo_id", "hpo_name", "hpo_ancestor_ids", "hpo_ancestor_names"], c.fetchone())))
     c.close()
     return hpos
-
-

--- a/views/users.py
+++ b/views/users.py
@@ -124,11 +124,18 @@ def create_user_idividual():
             # TODO: should not all these checks happen at the DB?
             if db_session.query(User.user).filter(User.user.match(u.user)).count() != 1:
                 raise PhenopolisException("Trying to add an entry in user_individual to a non existing user")
-            if db_session.query(Individual.internal_id).filter(Individual.internal_id.match(u.internal_id))\
-                    .count() != 1:
+            if (
+                db_session.query(Individual.internal_id).filter(Individual.internal_id.match(u.internal_id)).count()
+                != 1
+            ):
                 raise PhenopolisException("Trying to add an entry in user_individual to a non existing individual")
-            if db_session.query(User_Individual).filter(User_Individual.user.match(u.user)).filter(
-                                                        User_Individual.internal_id.match(u.internal_id)).count() > 0:
+            if (
+                db_session.query(User_Individual)
+                .filter(User_Individual.user.match(u.user))
+                .filter(User_Individual.internal_id.match(u.internal_id))
+                .count()
+                > 0
+            ):
                 raise PhenopolisException("Trying to add an entry in user_individual that already exists")
             db_session.add(u)
         db_session.commit()


### PR DESCRIPTION
Adds an endpoint `user-individuals` to post entries to the user_individuals table.

It can accept either a single user_individual:
```
{
        "user":"test_creation3",
        "internal_id":"PH00008639"
}
```

or a list of them:
```
[
    {
        "user":"test_creation3",
        "internal_id":"PH00008639"
    },
    {
        "user":"test_creation3",
        "internal_id":"PH00008640"
    }
]
```

Error conditions:
* Only Admin user is allowed
* Any other payload mimetype than application/json is rejected
* Empty payload
* Any field in the JSON not existing in the user SQLAlchemy model
* Empty `user` field
* Empty `internal_id` field
* Non existing user
* Non existing individual
* Already existing entry in `users_individuals`

NOTE: should not this last 3 error conditions be controlled in the database through PKs and FKs?

Also, I did a bit of refactoring to reuse the code in the three POST endpoints `user`, `individual` and `user-individuals`, and now both `user` and `individual` also accept a list of entries similarly to what is described above.

There is some naive examples in the postman collection here https://www.getpostman.com/collections/d13ec50102ab57bfe7c8 (beware that you would need to change the credentials to Admin for those to work and that they point to localhost:5000)
