### PR TITLE
Don't expose port 5432

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,3 @@ services:
       - public.env
       - private.env
       working_dir: /app
-      ports:
-      - 5432:5432


### PR DESCRIPTION
If there is the need to have the port open in other environment the thing can be done using two overlaying docker-compose files.

