### PR TITLE
Separate the app db user from the superuser and default db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
       image: postgres:12-alpine
       volumes:
       - ./:/app
-      - ./db/import_schema.sql:/docker-entrypoint-initdb.d/1_import_schema.sql
-      - ./db/import_demo_data.sql:/docker-entrypoint-initdb.d/2_import_demo_data.sql
+      - ./schema/initdb.d/:/docker-entrypoint-initdb.d
       env_file:
       - public.env
       - private.env

--- a/public.env
+++ b/public.env
@@ -1,4 +1,7 @@
-POSTGRES_HOST=db
-POSTGRES_DB=phenopolis_db
-POSTGRES_USER=phenopolis_api
-POSTGRES_PASSWORD=phenopolis_api
+POSTGRES_PASSWORD=postgres
+
+PH_DB_HOST=db
+PH_DB_NAME=phenopolis_db
+PH_DB_USER=phenopolis_api
+PH_DB_PASSWORD=phenopolis_api
+PH_DB_PORT=5432

--- a/schema/initdb.d/10_create_user.sh
+++ b/schema/initdb.d/10_create_user.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+# set -x
+
+psql -c "create user ${PH_DB_USER}"
+psql -c "alter user ${PH_DB_USER} with password '${PH_DB_PASSWORD}'"

--- a/schema/initdb.d/20_create_database.sh
+++ b/schema/initdb.d/20_create_database.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+psql -c "create database ${PH_DB_NAME}"

--- a/schema/initdb.d/30_import_old_schema.sh
+++ b/schema/initdb.d/30_import_old_schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+psql -1X --set ON_ERROR_STOP=1 -f "/app/db/import_schema.sql" \
+    "dbname=${PH_DB_NAME}"

--- a/schema/initdb.d/40_import_old_demo.sh
+++ b/schema/initdb.d/40_import_old_demo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+psql -1X --set ON_ERROR_STOP=1 -f "/app/db/import_demo_data.sql" \
+    "dbname=${PH_DB_NAME}"

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -53,11 +53,11 @@ def _load_config():
     application.config["MAIL_USE_TLS"] = os.getenv("MAIL_USE_TLS", "true") == "true"
     application.config["MAIL_USE_SSL"] = os.getenv("MAIL_USE_SSL", "false") == "true"
     application.config["MAIL_SUPPRESS_SEND"] = os.getenv("MAIL_SUPPRESS_SEND", "true") == "true"
-    application.config["DB_HOST"] = os.getenv("POSTGRES_HOST", "0.0.0.0")
-    application.config["DB_DATABASE"] = os.getenv("POSTGRES_DB", "phenopolis_db")
-    application.config["DB_USER"] = os.getenv("POSTGRES_USER", "phenopolis_api")
-    application.config["DB_PASSWORD"] = os.getenv("POSTGRES_PASSWORD", "phenopolis_api")
-    application.config["DB_PORT"] = os.getenv("POSTGRES_PORT", "5432")
+    application.config["DB_HOST"] = os.getenv("PH_DB_HOST", "0.0.0.0")
+    application.config["DB_DATABASE"] = os.getenv("PH_DB_NAME", "phenopolis_db")
+    application.config["DB_USER"] = os.getenv("PH_DB_USER", "phenopolis_api")
+    application.config["DB_PASSWORD"] = os.getenv("PH_DB_PASSWORD", "phenopolis_api")
+    application.config["DB_PORT"] = os.getenv("PH_DB_PORT", "5432")
     application.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = True
     db_uri = "postgresql+psycopg2://%s:%s@%s/%s" % (
         application.config["DB_USER"],


### PR DESCRIPTION
This changeset changes the way the docker image is created.

- create the default postgres superuser and database
- create the phenopolis_api as non-superuser

In general we would like that the app user is not a superuser, but we
still want a superuser in the system to manage the schema. That can be
any superuser (normally postgres, but probably rdsadmin in rds).

Please review the changes in case some configuration is changed which would break dev/prod.