### PR TITLE
Use a persistent volume for the db in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,13 @@ services:
    db:
       image: postgres:12-alpine
       volumes:
+      - db:/var/lib/postgresql/data
       - ./:/app
       - ./schema/initdb.d/:/docker-entrypoint-initdb.d
       env_file:
       - public.env
       - private.env
       working_dir: /app
+
+volumes:
+  db:


### PR DESCRIPTION
Without this volume, not only the database is lost after each down, but
the volume is not dropped, so it will leak.

Have a `docker volume ls` on your machine: that's all data you can drop
(using `docker volume prune`).