### PR TITLE
Made HPO tables writable by the phenopolis_api user

### DIFF
--- a/schema/database.sql
+++ b/schema/database.sql
@@ -26,7 +26,9 @@ create extension ltree;
 create schema hpo;
 grant usage on schema hpo to phenopolis_api;
 alter default privileges in schema hpo
-    grant select on tables to phenopolis_api;
+    grant select, insert, update, delete on tables to phenopolis_api;
+alter default privileges in schema hpo
+    grant all on sequences to phenopolis_api;
 
 set search_path to hpo, public;
 \i hpo.sql


### PR DESCRIPTION
To be strict, this user should be given read only permission. However
this probably makes many things simpler. We can restrict permissions
later.

Part of #142