### PR TITLE
Create phenopolis_api as a role rather than an user in the database

### DIFF
--- a/schema/globals.sql
+++ b/schema/globals.sql
@@ -4,9 +4,9 @@
 
 do $$
 begin
-    perform 1 from pg_user where usename = 'phenopolis_api';
+    perform 1 from pg_roles where rolname = 'phenopolis_api';
     if not found then
-        create user phenopolis_api;
+        create role phenopolis_api;
     end if;
 end
 $$ language plpgsql;


### PR DESCRIPTION
Roles and users are almost the same: a role is a user that by default
cannot log in (but it can be changed to do so). On dev/prod there are
two different db users, so it makes more sense to associate object
permissions to a single role (phenopolis_api) and make the two users
member of the role, e.g. using:

   GRANT phenopolis_api TO phenopolis_dev_user;

In docker-compose the phenopolis_api role is created at container first
start, as an user so it can be used for login.