### PR TITLE
hpo description fields size increased

### DIFF
--- a/schema/hpo.sql
+++ b/schema/hpo.sql
@@ -19,7 +19,7 @@ create table xref (
     term_id integer references term (id),
     xref text not null check (length(xref) <= 50 and xref !~ '^\s|\s$|^$'),
     description text
-    check (length(description) <= 200 and trim(description) != ''),
+    check (length(description) <= 1000 and trim(description) != ''),
     primary key (term_id, xref));
 
 create index on xref (xref);
@@ -29,7 +29,7 @@ create table synonym (
     id serial primary key,
     term_id integer references term (id),
     description text
-        check (length(description) <= 200 and trim(description) != ''));
+        check (length(description) <= 1000 and trim(description) != ''));
 
 create index on synonym (term_id);
 

--- a/schema/patches/2020-09-04_larger_hpo.sql
+++ b/schema/patches/2020-09-04_larger_hpo.sql
@@ -1,0 +1,7 @@
+set search_path to hpo, public;
+
+alter table synonym drop constraint synonym_description_check;
+alter table synonym add check (length(description) <= 1000 and trim(description) != '');
+
+alter table xref drop constraint xref_description_check;
+alter table xref add check (length(description) <= 1000 and trim(description) != '');


### PR DESCRIPTION
Trying an import as of now, the previous size wasn't enough for at least one synonym.