### PR TITLE
Added script to import Kaviar annotations

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -77,7 +77,7 @@ into COPY format in order to leave the import destination flexible. For
 instance:
 
 ```
-    import_gnomad.py -v https://example.com/gnomad.genomes.r3.0.sites.chr22.vcf.bgz \
+import_gnomad.py -v https://example.com/gnomad.genomes.r3.0.sites.chr22.vcf.bgz \
     | psql -c "copy gnomad.annotation_v3 from stdin" \
         "host=$(scripts/dchost db) user=phenopolis_api dbname=phenopolis_db"
 ```
@@ -103,6 +103,29 @@ In order to load hbo files in the docker db:
 dc exec app python3 ./scripts/import_hpo.py \
     --dsn "host=db user=postgres dbname=phenopolis_db"
 ```
+
+
+Kaviar import
+-------------
+
+Kaviar annotations can be imported using the `script/import_kaviar.py` script.
+The import input can be a local file or an url to downlaod. Note that (chrom,
+pos, ref, alt) is nit unique, so the table has an auto-increment `id` field
+too.
+
+The script prints on stdout data compatible with the `COPY` command. It can be
+used as:
+
+```
+./scripts/import_kaviar.py -v \
+    http://s3-us-west-2.amazonaws.com/kaviar-160204-public/Kaviar-160204-Public-hg19.vcf.tar \
+    | psql -c "copy kaviar.annotation_hg19 (chrom, pos, ref, alt, ac, af, an, ds) from stdin" \
+        "host=$(dchost db) dbname=phenopolis_db user=postgres"
+```
+
+You can monitor the import status using the `\dt+ kaviar.annotation_hg19_*`
+psql command. Using `-v`, the script will print periodically on stdout the number of lines
+parsed: full import of hg19 version will read > 207M lines.
 
 
 Variants import

--- a/schema/database.sql
+++ b/schema/database.sql
@@ -68,6 +68,18 @@ set search_path to gnomad, public;
 reset search_path;
 
 
+create schema kaviar;
+grant usage on schema kaviar to phenopolis_api;
+alter default privileges in schema kaviar
+    grant select, insert, update, delete on tables to phenopolis_api;
+alter default privileges in schema kaviar
+    grant all on sequences to phenopolis_api;
+
+set search_path to kaviar, public;
+\i kaviar.sql
+reset search_path;
+
+
 create schema cadd;
 grant usage on schema cadd to phenopolis_api;
 alter default privileges in schema cadd

--- a/schema/kaviar.sql
+++ b/schema/kaviar.sql
@@ -1,0 +1,44 @@
+create table annotation_hg19 (
+    id bigserial,
+
+    -- not unique
+    chrom text not null,
+    pos int4 not null,
+    ref text not null,
+    alt text not null,
+
+    -- chrom needed in the pkey for partitioning
+    primary key (chrom, id),
+
+    ac int4,    -- allele count
+    af real,    -- allele frequency
+    an int4,    -- allele number
+    ds text     -- data source
+        check (length(ds) > 0)
+) partition by list (chrom);
+
+
+-- Create one partition per chrom value
+do $do$
+declare
+    chrom text;
+begin
+    for chrom in
+        select c::text from generate_series(1,22) c
+        union
+        values ('X'), ('Y'), ('M')
+        order by c
+    loop
+        execute format($$
+            create table annotation_hg19_%1$s
+                partition of annotation_hg19
+                for values in (%1$L)
+        $$, chrom);
+
+        execute format($$
+            create index on annotation_hg19_%1$s (pos);
+        $$, chrom);
+
+    end loop;
+end
+$do$ language plpgsql;

--- a/schema/patches/2020-09-12_kaviar.sql
+++ b/schema/patches/2020-09-12_kaviar.sql
@@ -1,0 +1,54 @@
+create schema kaviar;
+grant usage on schema kaviar to phenopolis_api;
+alter default privileges in schema kaviar
+    grant select, insert, update, delete on tables to phenopolis_api;
+alter default privileges in schema kaviar
+    grant all on sequences to phenopolis_api;
+
+set search_path to kaviar, public;
+
+create table annotation_hg19 (
+    id bigserial,
+
+    -- not unique
+    chrom text not null,
+    pos int4 not null,
+    ref text not null,
+    alt text not null,
+
+    primary key (chrom, id),
+
+    ac int4,    -- allele count
+    af real,    -- allele frequency
+    an int4,    -- allele number
+    ds text     -- data source
+        check (length(ds) > 0)
+) partition by list (chrom);
+
+
+-- Create one partition per chrom value
+do $do$
+declare
+    chrom text;
+begin
+    for chrom in
+        select c::text from generate_series(1,22) c
+        union
+        values ('X'), ('Y'), ('M')
+        order by c
+    loop
+        execute format($$
+            create table annotation_hg19_%1$s
+                partition of annotation_hg19
+                for values in (%1$L)
+        $$, chrom);
+
+        execute format($$
+            create index on annotation_hg19_%1$s (pos);
+        $$, chrom);
+
+    end loop;
+end
+$do$ language plpgsql;
+
+reset search_path;

--- a/scripts/import_kaviar.py
+++ b/scripts/import_kaviar.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+r"""Import a kaviar file.
+
+Read a resource (file, url) and print on stdout a stream of data suitable
+for COPY. We'll see later what to do with it...
+
+Example usage:
+
+   import_kaviar.py -v http://s3-us-west-2.amazonaws.com/kaviar-160204-public/Kaviar-160204-Public-hg19.vcf.tar
+        | psql -c "copy kaviar.annotation_hg19 (chrom, pos, ref, alt, ac, af, an, ds) from stdin" \
+            "host=$(dchost db) dbname=phenopolis_db user=phenopolis_api"
+"""
+
+import re
+import os
+import sys
+import shlex
+import logging
+import subprocess as sp
+from shutil import which
+from contextlib import contextmanager
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+logger = logging.getLogger()
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(message)s")
+
+
+class ScriptError(Exception):
+    """Controlled exception raised by the script."""
+
+
+class VCFTransform:
+    """
+    Transform a stream of VCF data into data suitable for PostgreSQL COPY.
+    """
+
+    def __init__(self, fields):
+        self.fields = fields
+        self._field_regexps = [re.compile(rf"\b{re.escape(f)}=([^;]*)".encode("ascii")) for f in fields]
+        self.convert_line = self.convert_line_start
+        self.headers = {}  # map title -> col idx
+
+    def convert_line_start(self, line):
+        if line.startswith(b"##INFO"):
+            self.parse_info(line)
+        elif line.startswith(b"##"):
+            pass
+        elif line.startswith(b"#CHROM"):
+            self.parse_header(line)
+            self.convert_line = self.convert_line_data
+        return
+        yield
+
+    def parse_info(self, line):
+        # TODO, in case we need other types than int and float
+        pass
+
+    CHROM = 0
+    POS = 1
+    REF = 3
+    ALT = 4
+    INFO = 7
+
+    def parse_header(self, line):
+        headers = line.decode("ascii").lstrip("#").rstrip().split("\t")
+        self.headers = {col: i for i, col in enumerate(headers)}
+
+        # If these fail the converter must become more generic
+        assert self.headers["CHROM"] == self.CHROM
+        assert self.headers["POS"] == self.POS
+        assert self.headers["REF"] == self.REF
+        assert self.headers["ALT"] == self.ALT
+        assert self.headers["INFO"] == self.INFO
+
+    seen = set()
+
+    def convert_line_data(self, line):
+        fields = line.split(b"\t")
+        fields[-1] = fields[-1].rstrip()
+
+        chrom = fields[self.CHROM]
+        pos = fields[self.POS]
+        ref = fields[self.REF]
+        alts = fields[self.ALT].split(b",")
+
+        info = self.parse_info_field(fields[self.INFO])
+        afs = info["AF"].split(b",")
+        acs = info["AC"].split(b",")
+        if info["DS"]:
+            dss = info["DS"].split(b",")
+        else:
+            dss = [None] * len(alts)
+
+        for i in range(len(alts)):
+            out = [chrom, pos, ref, alts[i], acs[i], afs[i], info["AN"], dss[i] or b"\\N"]
+            yield b"\t".join(out) + b"\n"
+
+    def parse_info_field(self, data):
+        rv = {}
+        for field, rex in zip(self.fields, self._field_regexps):
+            m = rex.search(data)
+            rv[field] = m.group(1) if m is not None else None
+        return rv
+
+
+def main():
+    opt = parse_cmdline()
+    logger.setLevel(opt.loglevel)
+
+    tx = VCFTransform(fields=["AC", "AF", "AN", "DS"])
+
+    with open_stream(opt.spec) as f:
+        nr = nw = 0
+        for line in f:
+            nr += 1
+            if nr % 1_000_000 == 0:
+                logger.debug("%s lines read", nr)
+            for L in tx.convert_line(line):
+                nw += 1
+                sys.stdout.buffer.write(L)
+
+    logger.info("%s lines written", nw)
+
+
+@contextmanager
+def open_stream(spec):
+    """
+    Open a stream of vcf data to parse from a file spec.
+
+    - if it's an url, download it
+    - if it's a tar file, extract the vcf file contained within
+    - if the stream is compressed, expand it.
+
+    A file such as:
+
+       http://s3-us-west-2.amazonaws.com/kaviar-160204-public/Kaviar-160204-Public-hg19.vcf.tar
+
+    Is an archive containing a file called:
+
+        Kaviar-160204-Public/vcfs/Kaviar-160204-Public-hg19.vcf.gz
+
+    which contains the data to import.
+    """
+    is_remote = "://" in spec
+
+    if not is_remote:
+        if not os.path.exists(spec):
+            raise ScriptError(f"not a valid file: {spec}")
+
+    is_tar = ".tar" in spec
+
+    is_gzip = False
+    if not is_tar:
+        if spec.endswith(".vcf.gz"):
+            is_gzip = True
+        elif spec.endswith(".vcs"):
+            pass
+        else:
+            raise ScriptError(f"can't understand spec: {spec}")
+    else:
+        # tar contains gzip
+        is_gzip = True
+
+    cmdline = []
+
+    if is_remote:
+        if which("curl"):
+            cmdline.append("curl --silent")
+        elif which("wget"):
+            cmdline.append("wget --quiet -O")
+        else:
+            raise ScriptError("couldn't find curl or wget")
+        cmdline.append(shlex.quote(spec))
+        cmdline.append("|")
+
+    if is_tar:
+        cmdline.append("tar -xOf")
+        if is_remote:
+            cmdline.append("-")
+        else:
+            cmdline.append(shlex.quote(spec))
+
+        m = re.search(r"/Kaviar-(\d+)-Public-([^\./]+)", spec)
+        if not m:
+            raise ScriptError(f"can't find release number from {spec}")
+        cmdline.append(f"Kaviar-{m.group(1)}-Public/vcfs/Kaviar-{m.group(1)}-Public-{m.group(2)}.vcf.gz")
+        cmdline.append("|")
+
+    if is_gzip:
+        cmdline.append("gzip -cd")
+        if not (is_tar or is_remote):
+            cmdline.append(shlex.quote(spec))
+
+    cmdline = " ".join(cmdline)
+    logger.debug("reading data from command line: %s", cmdline)
+
+    with sp.Popen(cmdline, shell=True, stdout=sp.PIPE) as p:
+        yield p.stdout
+
+
+def parse_cmdline():
+    parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument("spec", metavar="FILE_OR_URL", help="the resource to parse")
+
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument(
+        "-q",
+        "--quiet",
+        help="talk less",
+        dest="loglevel",
+        action="store_const",
+        const=logging.WARN,
+        default=logging.INFO,
+    )
+    g.add_argument(
+        "-v",
+        "--verbose",
+        help="talk more",
+        dest="loglevel",
+        action="store_const",
+        const=logging.DEBUG,
+        default=logging.INFO,
+    )
+
+    opt = parser.parse_args()
+
+    return opt
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+
+    except ScriptError as e:
+        logger.error("%s", e)
+        sys.exit(1)
+
+    except Exception:
+        logger.exception("unexpected error")
+        sys.exit(1)
+
+    except KeyboardInterrupt:
+        logger.info("user interrupt")
+        sys.exit(1)


### PR DESCRIPTION
Added table `kaviar.annotation_hg19` and script to import data.

The table is partitioned on the chromosome, each partition is a few Gb

```
phenopolis_db-# \dt+ kaviar.annotation_hg19_*
                           List of relations
 Schema |        Name        | Type  |  Owner   |  Size   | Description 
--------+--------------------+-------+----------+---------+-------------
 kaviar | annotation_hg19_1  | table | postgres | 2194 MB | 
 kaviar | annotation_hg19_10 | table | postgres | 1347 MB | 
 kaviar | annotation_hg19_11 | table | postgres | 1368 MB | 
 kaviar | annotation_hg19_12 | table | postgres | 1324 MB | 
 kaviar | annotation_hg19_13 | table | postgres | 978 MB  | 
 kaviar | annotation_hg19_14 | table | postgres | 898 MB  | 
 kaviar | annotation_hg19_15 | table | postgres | 819 MB  | 
 kaviar | annotation_hg19_16 | table | postgres | 894 MB  | 
 kaviar | annotation_hg19_17 | table | postgres | 810 MB  | 
 kaviar | annotation_hg19_18 | table | postgres | 758 MB  | 
 kaviar | annotation_hg19_19 | table | postgres | 680 MB  | 
 kaviar | annotation_hg19_2  | table | postgres | 2324 MB | 
 kaviar | annotation_hg19_20 | table | postgres | 611 MB  | 
 kaviar | annotation_hg19_21 | table | postgres | 401 MB  | 
 kaviar | annotation_hg19_22 | table | postgres | 383 MB  | 
 kaviar | annotation_hg19_3  | table | postgres | 1940 MB | 
 kaviar | annotation_hg19_4  | table | postgres | 1940 MB | 
 kaviar | annotation_hg19_5  | table | postgres | 1742 MB | 
 kaviar | annotation_hg19_6  | table | postgres | 1745 MB | 
 kaviar | annotation_hg19_7  | table | postgres | 1608 MB | 
 kaviar | annotation_hg19_8  | table | postgres | 1485 MB | 
 kaviar | annotation_hg19_9  | table | postgres | 1194 MB | 
 kaviar | annotation_hg19_m  | table | postgres | 1464 kB | 
 kaviar | annotation_hg19_x  | table | postgres | 5253 MB | 
 kaviar | annotation_hg19_y  | table | postgres | 1045 MB | 
(25 rows)
```

(chrom, pos, ref, alt) is not unique, so the primary key is a sequence id. The schema is:

```
create table annotation_hg19 (
    id bigserial,

    -- not unique
    chrom text not null,
    pos int4 not null,
    ref text not null,
    alt text not null,

    -- chrom needed in the pkey for partitioning
    primary key (chrom, id),

    ac int4,    -- allele count
    af real,    -- allele frequency
    an int4,    -- allele number
    ds text     -- data source
        check (length(ds) > 0)
) partition by list (chrom);
```

Import can be performed from a local file or a remote url. Import from local file took about 35m on my laptop.

```
(.venv) piro@baloo:~/dev/Phenopolis/phenopolis_api$ ./scripts/import_kaviar.py -v ./Kaviar-160204-Public-hg19.vcf.tar | psql -c "copy kaviar.annotation_hg19 (chrom, pos, ref, alt, ac, af, an, ds) from stdin" "host=$(dchost db) dbname=phenopolis_db user=postgres"
2020-09-12 20:05:17,177 DEBUG 1000000 lines read
2020-09-12 20:05:26,130 DEBUG 2000000 lines read
...
2020-09-12 20:41:42,584 DEBUG 208000000 lines read
2020-09-12 20:42:01,451 INFO 224021477 lines written
COPY 224021477
Time: 2212297.477 ms (36:52.297)
```

As soon as the branch is merged I will import the data on dev-live too.