### PR TITLE
100 improve hgvs search

### DIFF
--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -13,7 +13,7 @@ from views.autocomplete import HPO_REGEX, NUMERIC_REGEX
         ("BRC", "gene", None),
         ("kiaa099", "gene", "gene::TTLL5::ENSG00000119685"),
         ("ENSG0000015617", "gene", "gene::DRAM2::ENSG00000156171"),
-        ("ENSG0000015617.3", "gene", "gene::DRAM2::ENSG00000156171"), # version is ignored
+        ("ENSG0000015617.3", "gene", "gene::DRAM2::ENSG00000156171"),  # version is ignored
         ("15617", "gene", "gene::DRAM2::ENSG00000156171"),
         ("ENST00000557636", "gene", "gene::TTLL5::ENSG00000119685"),
         ("557636", "gene", "gene::TTLL5::ENSG00000119685"),

--- a/views/autocomplete.py
+++ b/views/autocomplete.py
@@ -160,8 +160,10 @@ def _search_genes(query, limit):
             get_db_session()
             .query(Gene)
             .filter(
-                or_(Gene.gene_id.ilike("%{}%".format(query_without_version)),
-                    Gene.canonical_transcript.ilike("%{}%".format(query_without_version)))
+                or_(
+                    Gene.gene_id.ilike("%{}%".format(query_without_version)),
+                    Gene.canonical_transcript.ilike("%{}%".format(query_without_version)),
+                )
             )
             .order_by(Gene.gene_id.asc())
             .limit(limit)
@@ -282,22 +284,23 @@ def _search_variants_by_hgvs(hgvs_type, entity, hgvs, limit) -> List[Variant]:
             ensembl_gene_id_without_version = remove_version_from_id(entity)
             variants = (
                 get_db_session()
-                    .query(Variant)
-                    .filter(and_(Variant.gene_id == ensembl_gene_id_without_version,
-                                 Variant.hgvsc.ilike("%{}%".format(hgvs))))
-                    .order_by(Variant.CHROM.asc(), Variant.POS.asc())
-                    .limit(limit)
-                    .all()
+                .query(Variant)
+                .filter(
+                    and_(Variant.gene_id == ensembl_gene_id_without_version, Variant.hgvsc.ilike("%{}%".format(hgvs)))
+                )
+                .order_by(Variant.CHROM.asc(), Variant.POS.asc())
+                .limit(limit)
+                .all()
             )
         else:
             # search for HGVS on the variants for the given gene symbol
             variants = (
                 get_db_session()
-                    .query(Variant)
-                    .filter(and_(Variant.gene_symbol == entity, Variant.hgvsc.ilike("%{}%".format(hgvs))))
-                    .order_by(Variant.CHROM.asc(), Variant.POS.asc())
-                    .limit(limit)
-                    .all()
+                .query(Variant)
+                .filter(and_(Variant.gene_symbol == entity, Variant.hgvsc.ilike("%{}%".format(hgvs))))
+                .order_by(Variant.CHROM.asc(), Variant.POS.asc())
+                .limit(limit)
+                .all()
             )
     elif hgvs_type == HGVSP:
         if ENSEMBL_PROTEIN_REGEX.match(entity):
@@ -319,8 +322,11 @@ def _search_variants_by_hgvs(hgvs_type, entity, hgvs, limit) -> List[Variant]:
             variants = (
                 get_db_session()
                 .query(Variant)
-                .filter(and_(Variant.gene_id == ensembl_protein_id_without_version,
-                             Variant.hgvsp.ilike("%{}%".format(hgvs))))
+                .filter(
+                    and_(
+                        Variant.gene_id == ensembl_protein_id_without_version, Variant.hgvsp.ilike("%{}%".format(hgvs))
+                    )
+                )
                 .order_by(Variant.CHROM.asc(), Variant.POS.asc())
                 .limit(limit)
                 .all()


### PR DESCRIPTION
Solves #100 

### Changes
- Search by HGVS now accepts gene symbol and gene id for both HGVS c and p. 
- Search by gene id now ignores the version of the id

All of the below queries will return the same results:
```
ENST00000286692.4:c.*242A>G
ENST00000286692:c.*242A>G
DRAM2:c.*242A>G
ENSG00000156171:c.*242A>G
```

**Note**: the queries using an Ensembl transcript and protein id for HGVS c and p respectively, will be slower than when using the gene symbol or the gene id. This is because the transcript and protein ids are not available in the `variants` table and thus a full scan is required. This should be fixed in the new model.
**Note 2**: in the new DB model we decided not to use external identifiers (eg: Ensembl ids) as our internals PKs and FKs. This forces us to make a join in this case in order to filter out variant by a transcript Ensembl id. We better keep an eye on the impact on performance of this.
