### PR TITLE
add self-signed https between LB + Web servers within the VPC

### DIFF
--- a/.ebextensions/https-instance-securitygroup.config
+++ b/.ebextensions/https-instance-securitygroup.config
@@ -1,0 +1,9 @@
+Resources:
+  sslSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
+      CidrIp: 0.0.0.0/0

--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -2,7 +2,7 @@ branch-defaults:
   prod-live:
     environment: Phenopolis-prod
   dev-live:
-    environment: Phenopolis-dev
+    environment: phenopolis-live-dev
 environment-defaults:
   Phenopolis-prod:
     branch: null

--- a/.platform/hooks/postdeploy/01_install_ssl_certificates.sh
+++ b/.platform/hooks/postdeploy/01_install_ssl_certificates.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -f "/etc/pki/tls/certs/server-key.pem" ]; then
+  echo '/etc/pki/tls/certs/server-key.pem already exists'
+else
+  openssl req -x509 -sha256 -nodes -newkey rsa:4096 -days 365 \
+    -keyout /etc/pki/tls/certs/server-key.pem \
+    -out /etc/pki/tls/certs/server-cert.pem \
+    -subj "/C=GB/ST=London/L=London/O=Phenopolis/OU=Org/CN=api-dev.phenopolis.org"
+fi
+
+if [ -f "/etc/nginx/conf.d/webapp-ssl.conf" ]; then
+  echo '/etc/nginx/conf.d/webapp-ssl.conf already exists'
+else
+  mv /etc/nginx/conf.d/webapp-ssl.pre /etc/nginx/conf.d/webapp-ssl.conf
+fi
+
+echo "Restarting nginx"
+nginx -t
+nginx -s reload

--- a/.platform/nginx/conf.d/webapp-ssl.pre
+++ b/.platform/nginx/conf.d/webapp-ssl.pre
@@ -1,0 +1,25 @@
+server {
+  listen       443 ssl;
+  server_name _ localhost; # need to listen to localhost for worker tier
+
+  ssl_certificate      /etc/pki/tls/certs/server-cert.pem;
+  ssl_certificate_key  /etc/pki/tls/certs/server-key.pem;
+
+  ssl_session_timeout  5m;
+
+  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers   on;
+
+  location / {
+    proxy_pass          http://127.0.0.1:8000;
+    proxy_http_version  1.1;
+
+    proxy_set_header    Connection          $connection_upgrade;
+    proxy_set_header    Upgrade             $http_upgrade;
+    proxy_set_header    Host                $host;
+    proxy_set_header    X-Real-IP           $remote_addr;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    gzip_static on;
+    gzip on;
+  }
+}


### PR DESCRIPTION
I have updated the Elastic Beanstalk Environment to use a single Load Balancer for both the live and dev API servers (as they are both in the same VPC).

Moreover, this change sets up SSL between the Load Balancer + the web servers (i.e. the internal connection within the VPC). This is with a self-signed SSL certificate rather than an official one as I couldn't get it working with Let'sEncrypt (as it cannot validate itself inside the VPC). 

Eventually, we should replace this self-signed certificate with a proper wildcard SSL certificate (that we purchase). 

Saying that, I do not think this is a huge issue as this self-signed certificate is only used for the internal network (to get end-to-end encryption) and the end-users only see an Amazon signed wildcard SSL certificate

I am going to go ahead and merge this so that I can make the corresponding changes on AWS...