### PR TITLE
Fixed audit table for users after `enabled` field was added.

### DIFF
--- a/schema/patches/2020-09-13_disabled_users_flag_audit.sql
+++ b/schema/patches/2020-09-13_disabled_users_flag_audit.sql
@@ -1,0 +1,5 @@
+set search_path to phenopolis, public;
+
+alter table audit."public.users" add column enabled boolean;
+
+reset search_path;


### PR DESCRIPTION
See #208.