### PR TITLE
Fix varaint preview

### DIFF
--- a/frontend/src/components/Chip/TypeChip.js
+++ b/frontend/src/components/Chip/TypeChip.js
@@ -162,28 +162,28 @@ const TypeChip = (props) => {
             {error ? (
               <span> Can not Fetch preview information </span>
             ) : (
-                previewInfo.map((item, index) => {
-                  return (
-                    <Grid container spacing={1} key={index}>
-                      <Grid item xs={4} className="chip-popover-namegrid">
-                        {item[0]}
-                      </Grid>
+              previewInfo.map((item, index) => {
+                return (
+                  <Grid container spacing={1} key={index}>
+                    <Grid item xs={4} className="chip-popover-namegrid">
+                      {item[0]}
+                    </Grid>
 
-                      <Grid item xs={8} className="chip-popover-datagrid">
-                        {typeof item[1] === 'object'
-                          ? item[1].map((subchip, subchipIndex) => {
+                    <Grid item xs={8} className="chip-popover-datagrid">
+                      {typeof item[1] === 'object'
+                        ? item[1].map((subchip, subchipIndex) => {
                             return (
                               <span key={subchipIndex}>
                                 {subchipIndex === 0 ? '' : ', '} {subchip}
                               </span>
                             );
                           })
-                          : item[1]}
-                      </Grid>
+                        : item[1]}
                     </Grid>
-                  );
-                })
-              )}
+                  </Grid>
+                );
+              })
+            )}
           </Container>
         ) : null}
       </Popover>

--- a/frontend/src/redux/actions/preview.js
+++ b/frontend/src/redux/actions/preview.js
@@ -12,15 +12,14 @@ export const getPreviewInformation = (text) => {
     dispatch({ type: GET_PREVIEW });
     Service.getPreviewInformation(text)
       .then((res) => {
-
         if (/variant/.test(res.config.url)) {
-          var previewName = res.config.url.split('/')[4]
-          var result = Object.entries(res.data)
+          var previewName = res.config.url.split('/')[4];
+          var result = Object.entries(res.data);
         } else {
-          var previewName = res.config.url.split('/')[3]
-          var result = res.data[0].preview
+          var previewName = res.config.url.split('/')[3];
+          var result = res.data[0].preview;
         }
-        console.log(result)
+        console.log(result);
 
         dispatch({
           type: GET_PREVIEW_SUCCESS,
@@ -28,7 +27,6 @@ export const getPreviewInformation = (text) => {
         });
       })
       .catch((error) => {
-
         if (error.response.status === 401) {
           dispatch({
             type: SET_STATUS,

--- a/frontend/src/redux/actions/user.js
+++ b/frontend/src/redux/actions/user.js
@@ -133,7 +133,6 @@ export const enableUser = (param) => {
     dispatch({ type: ENABLE_USER_REQUEST });
     Service.enableUser(param)
       .then((res) => {
-
         if (param.status === true) {
           dispatch({
             type: SET_SNACK,
@@ -171,7 +170,6 @@ export const changePassword = (data) => {
     dispatch({ type: CHANGE_PASSWORD_REQUEST });
     Service.changePassword(data)
       .then((res) => {
-
         dispatch({
           type: SET_SNACK,
           payload: { newMessage: 'Change Password Success.', newVariant: 'success' },

--- a/frontend/src/redux/service.js
+++ b/frontend/src/redux/service.js
@@ -27,11 +27,11 @@ function getPreviewInformation(param) {
   // var previewURL = api.BASE_URL + param + api.FETCH_PREVIEW
 
   if (/variant/.test(param)) {
-    var previewURL = api.BASE_URL + '/variant/preview/' + param.split('/').slice(-1)[0]
+    var previewURL = api.BASE_URL + '/variant/preview/' + param.split('/').slice(-1)[0];
   } else {
-    var previewURL = api.BASE_URL + param + api.FETCH_PREVIEW
+    var previewURL = api.BASE_URL + param + api.FETCH_PREVIEW;
   }
-  console.log(previewURL)
+  console.log(previewURL);
   return axios.get(previewURL, {
     withCredentials: true,
   });


### PR DESCRIPTION
Variant Preview is working now, by an extremely ugly fix that I use regex to find if it's a "Variant Preview" or "Other Preview", then two sets of API pre-calling and post-calling code is implemented.

This is not a good way. I hope all previews', tables' and meta's format should be exactly the same. Customization is the enemy of universal components.