### PR TITLE
fix #307

### DIFF
--- a/frontend/src/components/UpdatePatient/FileUpload.js
+++ b/frontend/src/components/UpdatePatient/FileUpload.js
@@ -1,14 +1,13 @@
 import React, { Fragment, useEffect } from 'react';
 import { Container, Card, Divider, Typography, Grid, IconButton, Box } from '@material-ui/core';
 import axios from 'axios';
-import fileDownload from 'js-file-download';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCloudDownload, faFileAlt, faTrashAlt } from '@fortawesome/pro-solid-svg-icons';
 
 import 'uppy/dist/uppy.min.css';
 import Uppy from '@uppy/core';
-import { DragDrop, Dashboard, useUppy } from '@uppy/react';
+import { Dashboard, useUppy } from '@uppy/react';
 import AwsS3 from '@uppy/aws-s3';
 
 import { useDispatch, useSelector } from 'react-redux';
@@ -49,10 +48,15 @@ export default function FileUpload(props) {
       dispatch(getFiles(patientID));
     }
     if (downloadFileLoaded) {
-      fileDownload(downloadURL.response, downloadURL.filename.match(/_(.*)/)[1]);
+      window.location.href = downloadURL.response;
     }
     dispatch(resetFile());
   }, [deleteFileLoaded, downloadFileLoaded]);
+
+  useEffect(() => {
+    if (fetchFileLoaded) {
+    }
+  }, [fetchFileLoaded]);
 
   const uppy = useUppy(() => {
     return new Uppy({
@@ -108,9 +112,9 @@ export default function FileUpload(props) {
           <Container style={{ marginTop: '2em' }}>
             {fetchFileLoaded ? (
               <Grid container spacing={4}>
-                {files.Contents.map((item, index) => {
+                {files.response.Contents.map((item, index) => {
                   return (
-                    <Grid item xs={6} md={4}>
+                    <Grid key={index} item xs={6} md={4}>
                       <Card className="card-box text-black-50 bg-secondary mb-4 p-3">
                         <div className="d-flex align-items-center flex-column flex-sm-row">
                           <div>

--- a/frontend/src/redux/actions/files.js
+++ b/frontend/src/redux/actions/files.js
@@ -18,6 +18,7 @@ export const getFiles = (param) => {
     dispatch({ type: FETCH_FILES_REQUEST });
     Service.getFiles(param)
       .then((res) => {
+        console.log(res);
         dispatch({ type: FETCH_FILES_SUCCESS, payload: { data: res.data } });
       })
       .catch((error) => {

--- a/views/upload.py
+++ b/views/upload.py
@@ -15,6 +15,7 @@ UPLOAD_FOLDER = "upload"
 
 S3_KEY = os.getenv("VCF_S3_KEY")
 SECRET_ACCESS_KEY = os.environ.get("VCF_S3_SECRET")
+DOWNLOAD_SIGNED_URL_TIME = 300
 
 s3_client = boto3.client(
     "s3",
@@ -30,7 +31,6 @@ def presign_S3():
     data = request.get_json()
     filename = data.get("filename")
     prefix = data.get("prefix")
-    print(data)
 
     try:
         response = s3_client.generate_presigned_post(
@@ -63,7 +63,6 @@ def getUploadedFile(individual_id):
 def delete_file():
     data = request.get_json()
     fileKey = data.get("fileKey")
-    print(data, flush=True)
     response = s3_client.delete_object(Bucket="phenopolis-website-uploads", Key=fileKey)
 
     return jsonify(message="Delete File Success", response=response), 200
@@ -75,8 +74,6 @@ def download_file():
     data = request.get_json()
     fileKey = data.get("fileKey")
     response = s3_client.generate_presigned_url(
-        "get_object", Params={"Bucket": "phenopolis-website-uploads", "Key": fileKey}, ExpiresIn=3600
+        "get_object", Params={"Bucket": "phenopolis-website-uploads", "Key": fileKey}, ExpiresIn=DOWNLOAD_SIGNED_URL_TIME
     )
-    print("- - - - - ", flush=True)
-    print(response, flush=True)
     return jsonify(filename=fileKey, response=response), 200


### PR DESCRIPTION
It works now, file can be downloaded.

I did not change the backend API for download from "POST" to "GET", merely because the fileKey format is:
```
PH0000XXXX/somefilename
```
So if we use "GET" method, like:
```
download/PH0000XXXX/somefilename
```
The server would not go to API "download", instead if went to "download/PH0000XXXX/". But it's still possible to use "GET", then the fileKey must be send by param, like a string. I can change that if needed, I just think there is less difference between "GET" and "POST" here. 