### PR TITLE
Use decorator, user can delete/enable itself

### DIFF
--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -34,10 +34,15 @@ def test_delete_user_individual_without_permissions(_demo):
     _check_only_available_to_admin(res)
 
 
-def test_enable_user_without_permissions(_demo):
-    """res -> tuple(flask.wrappers.Response)"""
-    res = enable_user("my_user", "true")
-    _check_only_available_to_admin(res)
+def test_enable_user_special_permissions(_demo_client):
+    # try another user: not allowed
+    res = _demo_client.put("/user/nondemo/enabled/true")
+    assert res.status_code == 403
+    assert res.json == {"error": "Only Admin or the own User can perform this operation"}
+    # try itself: allowed
+    res = _demo_client.put("/user/demo/enabled/true")
+    assert res.status_code == 200
+    assert res.json == {"message": "User enabled flag set to 1", "success": True}
 
 
 def test_attempt_create_user_with_wrong_mimetype(_admin):

--- a/views/auth.py
+++ b/views/auth.py
@@ -70,6 +70,17 @@ def requires_admin(f):
     return decorated
 
 
+def requires_admin_or_user(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        user_id = kwargs.get("user_id")
+        if session.get(USER) in [ADMIN_USER, user_id]:
+            return f(*args, **kwargs)
+        return jsonify(error="Only Admin or the own User can perform this operation"), 403
+
+    return decorated
+
+
 @application.route("/<language>/login", methods=["POST"])
 @application.route("/login", methods=["POST"])
 def login():

--- a/views/users.py
+++ b/views/users.py
@@ -7,7 +7,7 @@ from passlib.handlers.argon2 import argon2
 from sqlalchemy import func
 from db.model import User, UserIndividual, UserConfig
 from views import MAIL_USERNAME, application, mail
-from views.auth import requires_auth, check_auth, requires_admin, is_demo_user, USER, ADMIN_USER
+from views.auth import requires_admin_or_user, requires_auth, check_auth, requires_admin, is_demo_user, USER, ADMIN_USER
 from views.exceptions import PhenopolisException
 from views.general import _parse_boolean_parameter
 from views.helpers import _get_json_payload
@@ -50,7 +50,7 @@ def change_password():
 
 
 @application.route("/user/<user_id>/enabled/<status>", methods=["PUT"])
-@requires_admin
+@requires_admin_or_user
 def enable_user(user_id, status):
     with session_scope() as db_session:
         try:
@@ -152,10 +152,9 @@ def confirm_user(token):
 
 
 @application.route("/user/<user_id>", methods=["DELETE"])
+@requires_admin_or_user
 def delete_user(user_id):
     with session_scope() as db_session:
-        if not session.get(USER) in [ADMIN_USER, user_id]:
-            return jsonify(error="Only Admin or the own User can perform this operation"), 403
         user = _get_user_by_id(db_session, user_id)
         request_ok = True
         http_status = 200


### PR DESCRIPTION
The idea here is, besides Admin, user can either:
- disable itself (stop using the service but don't get deleted); or
- be able to complete delete itself.

Note that if we intend to use this endpoint for User, then some frontend tweak is needed in the User's profile page or similar (think how user can change its password).

If we want just the Admin to operate, then it's just a matter of changing the decorator from `@requires_admin_or_user` to `@requires_admin`.