### PR TITLE
Added Skeleton to replace all loading. Except Auth and Translation lo…

### DIFF
--- a/frontend/src/page/ConfirmPage.js
+++ b/frontend/src/page/ConfirmPage.js
@@ -4,8 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { confirmRegistration, ResetConfirmRegistration } from '../redux/actions/user';
 
 import { Container, Paper, Typography, Box } from '@material-ui/core';
-
-import Loading from '../components/General/Loading';
+import Skeleton from '@material-ui/lab/Skeleton';
 
 export default function ConfirmPage() {
   const dispatch = useDispatch();
@@ -39,9 +38,9 @@ export default function ConfirmPage() {
 
   return (
     <Fragment>
-      {status !== null ? (
-        <div className={'login-root'}>
-          <Container maxWidth="md">
+      <div className={'login-root'}>
+        <Container maxWidth="md">
+          {status !== null ? (
             <Paper className={'login-paper2'}>
               <Typography component="div">
                 <Box fontWeight="900" fontSize="h4.fontSize" m={1}>
@@ -52,11 +51,11 @@ export default function ConfirmPage() {
                 </Box>
               </Typography>
             </Paper>
-          </Container>
-        </div>
-      ) : (
-        <Loading message={'Confirming User Registration'} />
-      )}
+          ) : (
+            <Skeleton height={300} />
+          )}
+        </Container>
+      </div>
     </Fragment>
   );
 }

--- a/frontend/src/page/Gene.js
+++ b/frontend/src/page/Gene.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { CssBaseline, Container } from '@material-ui/core';
-import Loading from '../components/General/Loading';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { useTranslation } from 'react-i18next';
 import { getGene } from '../redux/actions/gene';
 
@@ -28,33 +28,39 @@ const Gene = (props) => {
   }, []);
 
   return (
-    <>
-      {loaded ? (
-        <React.Fragment>
-          <CssBaseline />
-          <div className="myPatients-container">
-            <MetaData
-              metadata={geneInfo.metadata}
-              name={
-                geneInfo.metadata.data[0].gene_name +
-                ' - ' +
-                geneInfo.metadata.data[0].full_gene_name
-              }
+    <React.Fragment>
+      <CssBaseline />
+      <div className="myPatients-container">
+        {loaded ? (
+          <MetaData
+            metadata={geneInfo.metadata}
+            name={
+              geneInfo.metadata.data[0].gene_name + ' - ' + geneInfo.metadata.data[0].full_gene_name
+            }
+          />
+        ) : (
+          <Skeleton height={145} />
+        )}
+
+        {loaded ? (
+          <Container maxWidth="xl">
+            <VersatileTable
+              title={t('Gene.Variants_Analysis')}
+              subtitle={t('Gene.Variants Analysis_subtitle')}
+              tableData={geneInfo.variants}
+              genomePlot={true}
             />
-            <Container maxWidth="xl">
-              <VersatileTable
-                title={t('Gene.Variants_Analysis')}
-                subtitle={t('Gene.Variants Analysis_subtitle')}
-                tableData={geneInfo.variants}
-                genomePlot={true}
-              />
-            </Container>
-          </div>
-        </React.Fragment>
-      ) : (
-        <Loading message={t('Gene.message')} />
-      )}
-    </>
+          </Container>
+        ) : (
+          <>
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={150} />
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={450} />
+          </>
+        )}
+      </div>
+    </React.Fragment>
   );
 };
 

--- a/frontend/src/page/HPO.js
+++ b/frontend/src/page/HPO.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { CssBaseline, AppBar, Tabs, Tab, Container, Box, Typography } from '@material-ui/core';
-import Loading from '../components/General/Loading';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { useTranslation, Trans } from 'react-i18next';
 import SwipeableViews from 'react-swipeable-views';
 import TabPanel from '../components/Tab/Tabpanel';
@@ -56,136 +56,146 @@ const HPO = (props) => {
   };
 
   return (
-    <>
-      {loaded ? (
-        <React.Fragment>
-          <CssBaseline />
-          <div className="hpo-container">
-            <MetaData
-              metadata={hpoInfo.metadata}
-              name={hpoInfo.metadata.data[0].name + ' - ' + hpoInfo.metadata.data[0].id}
-            />
+    <React.Fragment>
+      <CssBaseline />
+      <div className="hpo-container">
+        {loaded ? (
+          <MetaData
+            metadata={hpoInfo.metadata}
+            name={hpoInfo.metadata.data[0].name + ' - ' + hpoInfo.metadata.data[0].id}
+          />
+        ) : (
+          <Skeleton height={145} />
+        )}
 
-            <Container maxWidth="xl">
-              <AppBar
-                className="hpo-tab_appbar"
-                position="static"
-                color="transparent"
-                elevation={0}
-                m={0}
-                p={0}>
+        {loaded ? (
+          <Container maxWidth="xl">
+            <AppBar
+              className="hpo-tab_appbar"
+              position="static"
+              color="transparent"
+              elevation={0}
+              m={0}
+              p={0}>
+              <Tabs
+                value={value}
+                onChange={handleChange}
+                indicatorColor="primary"
+                textColor="primary"
+                variant="fullWidth"
+                aria-label="full width tabs example"
+                classes={{ indicator: 'hpo-bigIndicator' }}>
+                {[
+                  t('HPO.INDIVIDUALS'),
+                  t('HPO.LITERATURE_GENES'),
+                  t('HPO.PHENOGENON'),
+                  t('HPO.SKAT'),
+                ].map((item, index) => {
+                  return <Tab key={index} label={item} {...a11yProps(index)} />;
+                })}
+              </Tabs>
+            </AppBar>
+          </Container>
+        ) : (
+          <Skeleton height={200} />
+        )}
+
+        {loaded ? (
+          <SwipeableViews index={value} onChangeIndex={handleChangeIndex}>
+            <TabPanel value={value} index={0} className="hpo-tabPannel">
+              <VersatileTable
+                tableData={hpoInfo.individuals}
+                title={t('HPO.Individuals')}
+                subtitle={t('HPO.Individuals_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+            <TabPanel value={value} index={1} className="hpo-tabPannel">
+              <VersatileTable
+                tableData={hpoInfo.literature_genes}
+                title={t('HPO.Literature_Genes')}
+                subtitle={t('HPO.Literature_Genes_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+
+            {/* Phenogenon tab is more complex. */}
+            <TabPanel value={value} index={2} className="hpo-tabPannel">
+              <Typography component="div">
+                <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
+                  {t('HPO.Phenogenon')}
+                </Box>
+                <Box fontWeight="fontWeightLight" mb={2}>
+                  {t('HPO.Phenogenon_subtitle')}
+                </Box>
+              </Typography>
+
+              <AppBar position="static" color="transparent" elevation={0} m={0} p={0}>
                 <Tabs
-                  value={value}
-                  onChange={handleChange}
+                  value={phenogenonvalue}
+                  onChange={handleChangePhenogenon}
                   indicatorColor="primary"
                   textColor="primary"
                   variant="fullWidth"
                   aria-label="full width tabs example"
                   classes={{ indicator: 'hpo-bigIndicator' }}>
-                  {[
-                    t('HPO.INDIVIDUALS'),
-                    t('HPO.LITERATURE_GENES'),
-                    t('HPO.PHENOGENON'),
-                    t('HPO.SKAT'),
-                  ].map((item, index) => {
+                  {[t('HPO.RECESSIVE'), t('HPO.DOMINANT')].map((item, index) => {
                     return <Tab key={index} label={item} {...a11yProps(index)} />;
                   })}
                 </Tabs>
               </AppBar>
-            </Container>
+              <SwipeableViews index={phenogenonvalue} onChangeIndex={handleChangePhenogenonIndex}>
+                <TabPanel className="hpo-tabPannel" value={phenogenonvalue} index={0}>
+                  <VersatileTable
+                    tableData={hpoInfo.phenogenon_recessive}
+                    title={t('Recessive')}
+                    subtitle={[
+                      <Trans i18nKey="HPO.RECESSIVE_subtitle">
+                        <b>Genotype</b> : With at least two variants on a given gene that have ExAC
+                        homozygous count not higher than <b style={{ color: '#2E84CF' }}>2</b>, and
+                        CADD phred score not lower than <b style={{ color: '#2E84CF' }}>15</b>.
+                      </Trans>,
+                    ]}
+                    genomePlot={false}
+                  />
+                </TabPanel>
+                <TabPanel className="hpo-tabPannel" value={phenogenonvalue} index={1}>
+                  <VersatileTable
+                    tableData={hpoInfo.phenogenon_dominant}
+                    title={t('Dominant')}
+                    subtitle={[
+                      <Trans i18nKey="HPO.DOMINANT_subtitle">
+                        <b>Genotype</b> : With at least one variant on a given gene that has an ExAC
+                        heterozygous count not higher than ",{' '}
+                        <b style={{ color: '#2E84CF' }}>0.0001</b>, ", and CADD phred score not
+                        lower than ", <b style={{ color: '#2E84CF' }}>15</b>, "."
+                      </Trans>,
+                    ]}
+                    genomePlot={false}
+                  />
+                </TabPanel>
+              </SwipeableViews>
+            </TabPanel>
 
-            <SwipeableViews index={value} onChangeIndex={handleChangeIndex}>
-              <TabPanel value={value} index={0} className="hpo-tabPannel">
-                <VersatileTable
-                  tableData={hpoInfo.individuals}
-                  title={t('HPO.Individuals')}
-                  subtitle={t('HPO.Individuals_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-              <TabPanel value={value} index={1} className="hpo-tabPannel">
-                <VersatileTable
-                  tableData={hpoInfo.literature_genes}
-                  title={t('HPO.Literature_Genes')}
-                  subtitle={t('HPO.Literature_Genes_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-
-              {/* Phenogenon tab is more complex. */}
-              <TabPanel value={value} index={2} className="hpo-tabPannel">
-                <Typography component="div">
-                  <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
-                    {t('HPO.Phenogenon')}
-                  </Box>
-                  <Box fontWeight="fontWeightLight" mb={2}>
-                    {t('HPO.Phenogenon_subtitle')}
-                  </Box>
-                </Typography>
-
-                <AppBar position="static" color="transparent" elevation={0} m={0} p={0}>
-                  <Tabs
-                    value={phenogenonvalue}
-                    onChange={handleChangePhenogenon}
-                    indicatorColor="primary"
-                    textColor="primary"
-                    variant="fullWidth"
-                    aria-label="full width tabs example"
-                    classes={{ indicator: 'hpo-bigIndicator' }}>
-                    {[t('HPO.RECESSIVE'), t('HPO.DOMINANT')].map((item, index) => {
-                      return <Tab key={index} label={item} {...a11yProps(index)} />;
-                    })}
-                  </Tabs>
-                </AppBar>
-                <SwipeableViews index={phenogenonvalue} onChangeIndex={handleChangePhenogenonIndex}>
-                  <TabPanel className="hpo-tabPannel" value={phenogenonvalue} index={0}>
-                    <VersatileTable
-                      tableData={hpoInfo.phenogenon_recessive}
-                      title={t('Recessive')}
-                      subtitle={[
-                        <Trans i18nKey="HPO.RECESSIVE_subtitle">
-                          <b>Genotype</b> : With at least two variants on a given gene that have
-                          ExAC homozygous count not higher than{' '}
-                          <b style={{ color: '#2E84CF' }}>2</b>, and CADD phred score not lower than{' '}
-                          <b style={{ color: '#2E84CF' }}>15</b>.
-                        </Trans>,
-                      ]}
-                      genomePlot={false}
-                    />
-                  </TabPanel>
-                  <TabPanel className="hpo-tabPannel" value={phenogenonvalue} index={1}>
-                    <VersatileTable
-                      tableData={hpoInfo.phenogenon_dominant}
-                      title={t('Dominant')}
-                      subtitle={[
-                        <Trans i18nKey="HPO.DOMINANT_subtitle">
-                          <b>Genotype</b> : With at least one variant on a given gene that has an
-                          ExAC heterozygous count not higher than ",{' '}
-                          <b style={{ color: '#2E84CF' }}>0.0001</b>, ", and CADD phred score not
-                          lower than ", <b style={{ color: '#2E84CF' }}>15</b>, "."
-                        </Trans>,
-                      ]}
-                      genomePlot={false}
-                    />
-                  </TabPanel>
-                </SwipeableViews>
-              </TabPanel>
-
-              <TabPanel value={value} index={3} className="hpo-tabPannel">
-                <VersatileTable
-                  tableData={hpoInfo.skat}
-                  title={t('HPO.SKAT')}
-                  subtitle={t('HPO.SKAT_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-            </SwipeableViews>
-          </div>
-        </React.Fragment>
-      ) : (
-        <Loading message={t('HPO.message')} />
-      )}
-    </>
+            <TabPanel value={value} index={3} className="hpo-tabPannel">
+              <VersatileTable
+                tableData={hpoInfo.skat}
+                title={t('HPO.SKAT')}
+                subtitle={t('HPO.SKAT_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+          </SwipeableViews>
+        ) : (
+          <>
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={150} />
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={450} />
+          </>
+        )}
+      </div>
+    </React.Fragment>
   );
 };
 

--- a/frontend/src/page/Individual.js
+++ b/frontend/src/page/Individual.js
@@ -81,14 +81,32 @@ const Individual = (props) => {
                 })}
               </span>
             ) : (
-              <Skeleton
-                animation={'wave'}
-                variant={'circle'}
-                height={50}
-                width={50}
-                style={{ top: 125 }}
-                className="individual-fab"
-              />
+              <>
+                <Skeleton
+                  animation={'wave'}
+                  variant={'circle'}
+                  height={50}
+                  width={50}
+                  style={{ top: 125 }}
+                  className="individual-fab"
+                />
+                <Skeleton
+                  animation={'wave'}
+                  variant={'circle'}
+                  height={50}
+                  width={50}
+                  style={{ top: 125, right: 180 }}
+                  className="individual-fab"
+                />
+                <Skeleton
+                  animation={'wave'}
+                  variant={'circle'}
+                  height={50}
+                  width={50}
+                  style={{ top: 125, right: 240 }}
+                  className="individual-fab"
+                />
+              </>
             )}
           </Container>
           {loaded ? (
@@ -156,7 +174,12 @@ const Individual = (props) => {
               </SwipeableViews>
             </>
           ) : (
-            <Skeleton height={550} />
+            <>
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={150} />
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={450} />
+            </>
           )}
         </div>
       </React.Fragment>

--- a/frontend/src/page/ManagePatient.js
+++ b/frontend/src/page/ManagePatient.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
@@ -9,8 +10,6 @@ import { Container, Dialog, Button, Typography, Box } from '@material-ui/core';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlusSquare } from '@fortawesome/pro-solid-svg-icons';
-
-import Loading from '../components/General/Loading';
 
 const VersatileTable = React.lazy(() => import('../components/BaseTable/VersatileTable'));
 
@@ -115,37 +114,49 @@ const ManagePatient = () => {
     <>
       <CssBaseline />
       <div className="myPatients-container">
-        {DataReady ? (
-          <>
-            <Container maxWidth="xl">
-              <Typography component="div">
-                <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
-                  Manage All Patient Here
-                </Box>
-                <Box fontWeight="fontWeightLight" mb={2}>
-                  Here you can create/update/delete patient.
-                </Box>
-              </Typography>
-              <Button
-                variant="contained"
-                color="primary"
-                startIcon={<FontAwesomeIcon icon={faPlusSquare} />}
-                style={{ backgroundColor: 'orange' }}
-                component={Link}
-                to="/create_patient">
-                Create New Patient
-              </Button>
+        <Container maxWidth="xl">
+          {DataReady ? (
+            <Typography component="div">
+              <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
+                Manage All Patient Here
+              </Box>
+              <Box fontWeight="fontWeightLight" mb={2}>
+                Here you can create/update/delete patient.
+              </Box>
+            </Typography>
+          ) : (
+            <Skeleton height={50} width={200} />
+          )}
 
-              <VersatileTable
-                tableData={PatientData}
-                genomePlot={false}
-                // onActionClick={handleActionClick}
-              />
-            </Container>
-          </>
-        ) : (
-          <Loading message={"Fetching all Patients' information..."} />
-        )}
+          {DataReady ? (
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<FontAwesomeIcon icon={faPlusSquare} />}
+              style={{ backgroundColor: 'orange' }}
+              component={Link}
+              to="/create_patient">
+              Create New Patient
+            </Button>
+          ) : (
+            <Skeleton height={30} width={200} />
+          )}
+
+          {DataReady ? (
+            <VersatileTable
+              tableData={PatientData}
+              genomePlot={false}
+              // onActionClick={handleActionClick}
+            />
+          ) : (
+            <>
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={150} />
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={450} />
+            </>
+          )}
+        </Container>
       </div>
     </>
   );

--- a/frontend/src/page/ManageUser.js
+++ b/frontend/src/page/ManageUser.js
@@ -3,9 +3,8 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import { useDispatch, useSelector } from 'react-redux';
 import { getAllUser } from '../redux/actions/user';
 
-import { Container, Dialog } from '@material-ui/core';
-
-import Loading from '../components/General/Loading';
+import { Container, Grid } from '@material-ui/core';
+import Skeleton from '@material-ui/lab/Skeleton';
 import UserList from '../components/ManageUser/UserList';
 
 const ManageUser = () => {
@@ -38,7 +37,16 @@ const ManageUser = () => {
             </Container>
           </>
         ) : (
-          <Loading message={"Fetching all User' information..."} />
+          <Grid container spacing={4}>
+            <Grid item xs={12} lg={4}>
+              <Skeleton height={50} width={200} />
+              <Skeleton height={30} width={200} />
+              <Skeleton variant="rect" height={550} />
+            </Grid>
+            <Grid item xs={12} lg={8}>
+              <Skeleton variant="rect" height={550} />
+            </Grid>
+          </Grid>
         )}
       </div>
     </>

--- a/frontend/src/page/MyPatient.js
+++ b/frontend/src/page/MyPatient.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { CssBaseline, Container, Typography, Box, Button } from '@material-ui/core';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Loading from '../components/General/Loading';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -26,40 +27,52 @@ const MyPatient = () => {
   }, [dispatch]);
 
   return (
-    <>
-      {loaded ? (
-        <React.Fragment>
-          <CssBaseline />
-          <div className="myPatients-container">
-            <Container maxWidth="xl">
-              <Typography component="div">
-                <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
-                  {t('MyPatient.My_Patients') +
-                    ' (' +
-                    t('MyPatient.Total') +
-                    ' ' +
-                    hpoInfo.preview[0][1] +
-                    ')'}
-                </Box>
-              </Typography>
-              <Button
-                variant="contained"
-                color="primary"
-                startIcon={<FontAwesomeIcon icon={faPlusSquare} />}
-                style={{ backgroundColor: 'orange' }}
-                component={Link}
-                to="/create_patient">
-                Create New Patient
-              </Button>
+    <React.Fragment>
+      <CssBaseline />
+      <div className="myPatients-container">
+        <Container maxWidth="xl">
+          {loaded ? (
+            <Typography component="div">
+              <Box fontWeight="900" fontSize="h4.fontSize" mb={0}>
+                {t('MyPatient.My_Patients') +
+                  ' (' +
+                  t('MyPatient.Total') +
+                  ' ' +
+                  hpoInfo.preview[0][1] +
+                  ')'}
+              </Box>
+            </Typography>
+          ) : (
+            <Skeleton height={50} width={200} />
+          )}
 
-              <VersatileTable tableData={hpoInfo.individuals} genomePlot={false} />
-            </Container>
-          </div>
-        </React.Fragment>
-      ) : (
-        <Loading message={t('MyPatient.message')} />
-      )}
-    </>
+          {loaded ? (
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<FontAwesomeIcon icon={faPlusSquare} />}
+              style={{ backgroundColor: 'orange' }}
+              component={Link}
+              to="/create_patient">
+              Create New Patient
+            </Button>
+          ) : (
+            <Skeleton height={30} width={200} />
+          )}
+
+          {loaded ? (
+            <VersatileTable tableData={hpoInfo.individuals} genomePlot={false} />
+          ) : (
+            <>
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={150} />
+              <div className="mt-4 mb-4" />
+              <Skeleton variant="rect" height={450} />
+            </>
+          )}
+        </Container>
+      </div>
+    </React.Fragment>
   );
 };
 

--- a/frontend/src/page/Variant.js
+++ b/frontend/src/page/Variant.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { CssBaseline, AppBar, Tabs, Tab, Container } from '@material-ui/core';
-import Loading from '../components/General/Loading';
+import Skeleton from '@material-ui/lab/Skeleton';
 import { useTranslation } from 'react-i18next';
 import SwipeableViews from 'react-swipeable-views';
 import TabPanel from '../components/Tab/Tabpanel';
@@ -50,92 +50,104 @@ const Variant = (props) => {
   };
 
   return (
-    <>
-      {loaded ? (
-        <React.Fragment>
-          <CssBaseline />
-          <div className="variant-container">
-            <MetaData
-              metadata={variantInfo.metadata}
-              name={variantInfo.metadata.data[0].variant_id[0].display}
-            />
+    <React.Fragment>
+      <CssBaseline />
+      <div className="variant-container">
+        {loaded ? (
+          <MetaData
+            metadata={variantInfo.metadata}
+            name={variantInfo.metadata.data[0].variant_id[0].display}
+          />
+        ) : (
+          <Skeleton height={145} />
+        )}
 
-            <Container maxWidth="xl">
-              <AppBar
-                className="variant-tab_appbar"
-                position="static"
-                color="transparent"
-                elevation={0}
-                m={0}
-                p={0}>
-                <Tabs
-                  value={value}
-                  onChange={handleChange}
-                  indicatorColor="primary"
-                  textColor="primary"
-                  variant="fullWidth"
-                  aria-label="full width tabs example"
-                  classes={{ indicator: 'variant-bigIndicator' }}>
-                  {[
-                    t('Variant.FREQUENCY'),
-                    t('Variant.CONSEQUENCES'),
-                    t('Variant.QUALITY'),
-                    t('Variant.INDIVIDUALS'),
-                    t('Variant.GENOTYPES'),
-                  ].map((item, index) => {
-                    return <Tab key={index} label={item} {...a11yProps(index)} />;
-                  })}
-                </Tabs>
-              </AppBar>
-            </Container>
-            <SwipeableViews index={value} onChangeIndex={handleChangeIndex}>
-              <TabPanel value={value} index={0} className="variant-tabPannel">
-                <VersatileTable
-                  tableData={variantInfo.frequency}
-                  title={t('Variant.Frequency')}
-                  subtitle={t('Variant.Frequency_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-              <TabPanel value={value} index={1} className="variant-tabPannel">
-                <VersatileTable
-                  tableData={variantInfo.consequence}
-                  title={t('Variant.Consequences')}
-                  subtitle={t('Variant.Consequences_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-              <TabPanel value={value} index={2} className="variant-tabPannel">
-                <VersatileTable
-                  tableData={variantInfo.quality}
-                  title={t('Variant.Quality')}
-                  subtitle={t('Variant.Quality_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-              <TabPanel value={value} index={3} className="variant-tabPannel">
-                <VersatileTable
-                  tableData={variantInfo.individuals}
-                  title={t('Variant.Individuals')}
-                  subtitle={t('Variant.Individuals_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-              <TabPanel value={value} index={4} className="variant-tabPannel">
-                <VersatileTable
-                  tableData={variantInfo.genotypes}
-                  title={t('Variant.Genotypes')}
-                  subtitle={t('Variant.Genotypes_subtitle')}
-                  genomePlot={false}
-                />
-              </TabPanel>
-            </SwipeableViews>
-          </div>
-        </React.Fragment>
-      ) : (
-        <Loading message={t('Variant.message')} />
-      )}
-    </>
+        {loaded ? (
+          <Container maxWidth="xl">
+            <AppBar
+              className="variant-tab_appbar"
+              position="static"
+              color="transparent"
+              elevation={0}
+              m={0}
+              p={0}>
+              <Tabs
+                value={value}
+                onChange={handleChange}
+                indicatorColor="primary"
+                textColor="primary"
+                variant="fullWidth"
+                aria-label="full width tabs example"
+                classes={{ indicator: 'variant-bigIndicator' }}>
+                {[
+                  t('Variant.FREQUENCY'),
+                  t('Variant.CONSEQUENCES'),
+                  t('Variant.QUALITY'),
+                  t('Variant.INDIVIDUALS'),
+                  t('Variant.GENOTYPES'),
+                ].map((item, index) => {
+                  return <Tab key={index} label={item} {...a11yProps(index)} />;
+                })}
+              </Tabs>
+            </AppBar>
+          </Container>
+        ) : (
+          <Skeleton height={200} />
+        )}
+
+        {loaded ? (
+          <SwipeableViews index={value} onChangeIndex={handleChangeIndex}>
+            <TabPanel value={value} index={0} className="variant-tabPannel">
+              <VersatileTable
+                tableData={variantInfo.frequency}
+                title={t('Variant.Frequency')}
+                subtitle={t('Variant.Frequency_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+            <TabPanel value={value} index={1} className="variant-tabPannel">
+              <VersatileTable
+                tableData={variantInfo.consequence}
+                title={t('Variant.Consequences')}
+                subtitle={t('Variant.Consequences_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+            <TabPanel value={value} index={2} className="variant-tabPannel">
+              <VersatileTable
+                tableData={variantInfo.quality}
+                title={t('Variant.Quality')}
+                subtitle={t('Variant.Quality_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+            <TabPanel value={value} index={3} className="variant-tabPannel">
+              <VersatileTable
+                tableData={variantInfo.individuals}
+                title={t('Variant.Individuals')}
+                subtitle={t('Variant.Individuals_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+            <TabPanel value={value} index={4} className="variant-tabPannel">
+              <VersatileTable
+                tableData={variantInfo.genotypes}
+                title={t('Variant.Genotypes')}
+                subtitle={t('Variant.Genotypes_subtitle')}
+                genomePlot={false}
+              />
+            </TabPanel>
+          </SwipeableViews>
+        ) : (
+          <>
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={150} />
+            <div className="mt-4 mb-4" />
+            <Skeleton variant="rect" height={450} />
+          </>
+        )}
+      </div>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
fix #265 Replace nearly all Loading with Skeleton, **except** for Auth and Translation loading. These two will be loaded when the first time called, and will only be load once. Since there are no "shapes" for Auth or Translation, I can't create a corresponding skeleton to replace them.